### PR TITLE
Add pre-commit hooks and code quality tools

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503
+exclude = .git,__pycache__,build,dist
+per-file-ignores =
+    # Ignore missing docstrings in __init__ files
+    __init__.py:D104
+    # Ignore missing docstrings in tests
+    tests/*:D100,D101,D102,D103

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-toml
+    -   id: check-merge-conflict
+    -   id: debug-statements
+    -   id: detect-private-key
+
+-   repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+    -   id: black
+        language_version: python3
+
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+        args: ["--profile", "black"]
+
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+    -   id: flake8
+        additional_dependencies: [
+            'flake8-docstrings',
+            'flake8-bugbear',
+            'flake8-comprehensions',
+            'flake8-simplify',
+        ]
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.7.0
+    hooks:
+    -   id: mypy
+        args: [--ignore-missing-imports]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,14 @@
+# Runtime dependencies
 pandas==2.0.3
 matplotlib==3.7.1
+
+# Development dependencies
+pre-commit==3.5.0
+black==23.11.0
+isort==5.12.0
+flake8==6.1.0
+flake8-docstrings==1.7.0
+flake8-bugbear==23.9.16
+flake8-comprehensions==3.14.0
+flake8-simplify==0.21.0
+mypy==1.7.0


### PR DESCRIPTION
This pull request introduces configuration changes to improve code quality and consistency by setting up linting and formatting tools. The most important changes include configuring `flake8` and adding a `.pre-commit-config.yaml` file to automate code checks with pre-commit hooks.

Configuration changes:

* [`.flake8`](diffhunk://#diff-6951dbb399883798a226c1fb496fdb4183b1ab48865e75eddecf6ceb6cf46442R1-R9): Added configuration for `flake8` to set maximum line length, extend ignore rules, and specify per-file ignores for missing docstrings in `__init__.py` files and tests.

Pre-commit hook setup:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R1-R41): Added configuration to use several pre-commit hooks for tasks such as checking for trailing whitespace, fixing end-of-file issues, checking YAML and TOML files, detecting merge conflicts, and more. Included hooks for `black`, `isort`, `flake8`, and `mypy` with specific versions and arguments.- Add pre-commit configuration
- Configure black, isort, flake8, and mypy
- Update requirements.txt with development dependencies
- Add flake8 configuration